### PR TITLE
fix: switch rust prefix to define a constant array, just like in c or…

### DIFF
--- a/src/xxd/generate.rs
+++ b/src/xxd/generate.rs
@@ -12,7 +12,7 @@ static PYTHON_PRE: &str = "data = [";
 static PYTHON_SEPERATOR: &str = ",";
 static PYTHON_POST: &str = "]";
 
-static RUST_PRE: &str = "let data = [";
+static RUST_PRE: &str = "pub const DATA: &'static[u8] = &[";
 static RUST_SEPERATOR: &str = ",";
 static RUST_POST: &str = "];";
 


### PR DESCRIPTION
Switch rust prefix to write a constant array like in C or CPP